### PR TITLE
Cc box on email

### DIFF
--- a/CmsData/Email/Emailer.cs
+++ b/CmsData/Email/Emailer.cs
@@ -413,7 +413,7 @@ namespace CmsData
             return aa;
         }
 
-        public void SendPeopleEmail(int queueid)
+        public void SendPeopleEmail(int queueid, List<int> ccids = null)
         {
             var emailqueue = EmailQueues.Single(ee => ee.Id == queueid);
             var sysFromEmail = Util.SysFromEmail;
@@ -455,6 +455,20 @@ namespace CmsData
                 }
                 SubmitChanges();
             }
+
+            foreach (var ccid in ccids)
+            {
+                var c = EmailQueueTos.Count(a => a.Id == emailqueue.Id && a.PeopleId == ccid);
+                if (c == 0)
+                {
+                    emailqueue.EmailQueueTos.Add(new EmailQueueTo
+                    {
+                        PeopleId = ccid,
+                        Guid = Guid.NewGuid(),
+                    });
+                }
+            }
+            SubmitChanges();
 
             var q = from To in EmailQueueTos
                     where To.Id == emailqueue.Id

--- a/CmsData/Email/Emailer.cs
+++ b/CmsData/Email/Emailer.cs
@@ -413,7 +413,7 @@ namespace CmsData
             return aa;
         }
 
-        public void SendPeopleEmail(int queueid, List<int> ccids = null)
+        public void SendPeopleEmail(int queueid, List<MailAddress> cc = null)
         {
             var emailqueue = EmailQueues.Single(ee => ee.Id == queueid);
             var sysFromEmail = Util.SysFromEmail;
@@ -456,20 +456,6 @@ namespace CmsData
                 SubmitChanges();
             }
 
-            foreach (var ccid in ccids)
-            {
-                var c = EmailQueueTos.Count(a => a.Id == emailqueue.Id && a.PeopleId == ccid);
-                if (c == 0)
-                {
-                    emailqueue.EmailQueueTos.Add(new EmailQueueTo
-                    {
-                        PeopleId = ccid,
-                        Guid = Guid.NewGuid(),
-                    });
-                }
-            }
-            SubmitChanges();
-
             var q = from To in EmailQueueTos
                     where To.Id == emailqueue.Id
                     where To.Sent == null
@@ -509,12 +495,47 @@ namespace CmsData
 #endif
             }
 
+            // Handle CC MailAddresses.  These do not get DoReplacement support.
+            if (cc != null)
+            {
+                foreach (var ma in cc)
+                {
+#if DEBUG
+#else
+                try
+                {
+#endif
+                if (Setting("sendemail", "true") != "false")
+                {
+                    List<MailAddress> mal = new List<MailAddress> {ma};
+                    Util.SendMsg(sysFromEmail, CmsHost, from,
+                        emailqueue.Subject, body, mal, emailqueue.Id, null);
+                }
+#if DEBUG
+#else
+                }
+                catch (Exception ex)
+                {
+                    Util.SendMsg(sysFromEmail, CmsHost, from,
+                        "sent emails - error: {0}".Fmt(CmsHost), ex.Message,
+                        Util.ToMailAddressList(from),
+                        emailqueue.Id, null);
+                    Util.SendMsg(sysFromEmail, CmsHost, from,
+                        "sent emails - error: {0}".Fmt(CmsHost), ex.Message,
+                        Util.SendErrorsTo(),
+                        emailqueue.Id, null);
+                }
+#endif
+                }
+            }
+
             emailqueue.Sent = DateTime.Now;
             if (emailqueue.Redacted ?? false)
                 emailqueue.Body = "redacted";
             else if (emailqueue.Transactional == false)
             {
                 var nitems = emailqueue.EmailQueueTos.Count();
+                if (cc != null) { nitems += cc.Count(); }
                 if (nitems > 1)
                     NotifySentEmails(from.Address, from.DisplayName,
                         emailqueue.Subject, nitems, emailqueue.Id);

--- a/CmsWeb/Areas/Main/Controllers/EmailController.cs
+++ b/CmsWeb/Areas/Main/Controllers/EmailController.cs
@@ -225,7 +225,7 @@ namespace CmsWeb.Areas.Main.Controllers
                     // set these again inside thread local storage
                     Util.UserEmail = userEmail;
                     Util.IsInRoleEmailTest = isInRoleEmailTest;
-                    db.SendPeopleEmail(id, m.CcPeopleIds);
+                    db.SendPeopleEmail(id, m.CcAddresses);
                 }
                 catch (Exception ex)
                 {

--- a/CmsWeb/Areas/Main/Controllers/EmailController.cs
+++ b/CmsWeb/Areas/Main/Controllers/EmailController.cs
@@ -225,7 +225,7 @@ namespace CmsWeb.Areas.Main.Controllers
                     // set these again inside thread local storage
                     Util.UserEmail = userEmail;
                     Util.IsInRoleEmailTest = isInRoleEmailTest;
-                    db.SendPeopleEmail(id);
+                    db.SendPeopleEmail(id, m.CcPeopleIds);
                 }
                 catch (Exception ex)
                 {

--- a/CmsWeb/Areas/Main/Models/Other/MassEmailer.cs
+++ b/CmsWeb/Areas/Main/Models/Other/MassEmailer.cs
@@ -33,15 +33,15 @@ namespace CmsWeb.Areas.Main.Models
         public bool PublicViewable { get; set; }
         public IEnumerable<string> Recipients { get; set; }
 
-        public List<int> CcPeopleIds;
+        public List<MailAddress> CcAddresses;
         public string Cc {
             get {
-                if (CcPeopleIds == null) { return null; }
-                return String.Join(",", CcPeopleIds);
+                if (CcAddresses == null) { return null; }
+                return String.Join(",", CcAddresses);
             }
             set {
-                if (value == null) { CcPeopleIds = null; }
-                else { CcPeopleIds = value.Split(',').Select(int.Parse).ToList(); }
+                if (value == null) { CcAddresses = null; }
+                else { CcAddresses = value.Split(',').Select(a => new MailAddress(a)).ToList(); }
             }
         }
 

--- a/CmsWeb/Areas/Main/Models/Other/MassEmailer.cs
+++ b/CmsWeb/Areas/Main/Models/Other/MassEmailer.cs
@@ -31,7 +31,20 @@ namespace CmsWeb.Areas.Main.Models
         public string Body { get; set; }
         public DateTime? Schedule { get; set; }
         public bool PublicViewable { get; set; }
-        public IEnumerable<string> Recipients { get; set; } 
+        public IEnumerable<string> Recipients { get; set; }
+
+        public List<int> CcPeopleIds;
+        public string Cc {
+            get {
+                if (CcPeopleIds == null) { return null; }
+                return String.Join(",", CcPeopleIds);
+            }
+            set {
+                if (value == null) { CcPeopleIds = null; }
+                else { CcPeopleIds = value.Split(',').Select(int.Parse).ToList(); }
+            }
+        }
+
 
         public string Host { get; set; }
 

--- a/CmsWeb/Areas/Main/Views/Email/Compose.cshtml
+++ b/CmsWeb/Areas/Main/Views/Email/Compose.cshtml
@@ -95,6 +95,12 @@
             </div>
           </div>
           <div class="form-group">
+              <label for="inputEmail3" class="col-sm-2 control-label">Cc:</label>
+              <div class="col-sm-10">
+                  <input type="text" id="Cc" name="Cc" class="form-control">
+              </div>
+          </div>
+          <div class="form-group">
             <label for="Subject" class="col-sm-2 control-label">Subject:</label>
             <div class="col-sm-10">
               <input name="Subject" id="Subject" size="75" value="@(c.TypeID == ContentTypeCode.TypeEmailTemplate ? "" : c.Title)" class="form-control" />

--- a/CmsWeb/Web.config
+++ b/CmsWeb/Web.config
@@ -37,9 +37,9 @@
     <add key="ProblemDomainsForEmail" value="yahoo.com,aol.com" />
     <add key="RouteDebugger:Enabled" value="false" />
     <!-- use (local) or .\SQLEXPRESS -->
-    <add key="dbserver" value="(local)" />
+    <add key="dbserver" value=".\SQLEXPRESS" />
     <!--Second half of db name like CMS_bellevue-->
-    <add key="host" value="bellevue" />
+    <add key="host" value="nre" />
   </appSettings>
   <connectionStrings configSource="ConnectionStrings.config" />
   <!--
@@ -616,13 +616,13 @@
   </runtime>
   <system.net>
     <mailSettings>
-      <smtp deliveryMethod="SpecifiedPickupDirectory">
+      <!--<smtp deliveryMethod="SpecifiedPickupDirectory">
         <specifiedPickupDirectory pickupDirectoryLocation="c:\email" />
         <network host="localhost" />
-      </smtp>
-      <!--<smtp from="david@touchpointsoftware.com">
-        <network host="127.0.0.1" port="25" password="" userName="" />
       </smtp>-->
+      <smtp from="batman@ehresman.org">
+        <network host="mail.ehresman.org" port="25" password="nianacl8" userName="nathan@ehresman.org" enableSsl="true"/>
+      </smtp>
     </mailSettings>
   </system.net>
   <location path="elmah.axd" inheritInChildApplications="false">

--- a/CmsWeb/Web.config
+++ b/CmsWeb/Web.config
@@ -616,12 +616,9 @@
   </runtime>
   <system.net>
     <mailSettings>
-      <!--<smtp deliveryMethod="SpecifiedPickupDirectory">
+      <smtp deliveryMethod="SpecifiedPickupDirectory">
         <specifiedPickupDirectory pickupDirectoryLocation="c:\email" />
         <network host="localhost" />
-      </smtp>-->
-      <smtp from="batman@ehresman.org">
-        <network host="mail.ehresman.org" port="25" password="nianacl8" userName="nathan@ehresman.org" enableSsl="true"/>
       </smtp>
     </mailSettings>
   </system.net>

--- a/CmsWeb/Web.config
+++ b/CmsWeb/Web.config
@@ -37,9 +37,9 @@
     <add key="ProblemDomainsForEmail" value="yahoo.com,aol.com" />
     <add key="RouteDebugger:Enabled" value="false" />
     <!-- use (local) or .\SQLEXPRESS -->
-    <add key="dbserver" value=".\SQLEXPRESS" />
+    <add key="dbserver" value="(local)" />
     <!--Second half of db name like CMS_bellevue-->
-    <add key="host" value="nre" />
+    <add key="host" value="bellevue" />
   </appSettings>
   <connectionStrings configSource="ConnectionStrings.config" />
   <!--
@@ -620,6 +620,9 @@
         <specifiedPickupDirectory pickupDirectoryLocation="c:\email" />
         <network host="localhost" />
       </smtp>
+      <!--<smtp from="david@touchpointsoftware.com">
+        <network host="127.0.0.1" port="25" password="" userName=""/>
+      </smtp>-->
     </mailSettings>
   </system.net>
   <location path="elmah.axd" inheritInChildApplications="false">


### PR DESCRIPTION
Refactored PR #39 to not use PeopleID.  I should have done it this way to begin with.

The main side effect this has is that CC emails do not go through the EmailReplacements.DoReplacements process since it is dependent upon EmailQueueTo which in turn is dependent upon PeopleID.  So CC-ed recipients do not have email body replacements of things like vote links, rsvp links, etc.

If we add support for CC's to be bvcms People, we would be able to do replacements on those emails though.
