### PR TITLE
Add recipients to email

### DIFF
--- a/CmsData/Email/Emailer.cs
+++ b/CmsData/Email/Emailer.cs
@@ -461,6 +461,15 @@ namespace CmsData
             {
                 foreach (var pid in AdditionalRecipients)
                 {
+                    // Protect against duplicate PeopleIDs ending up in the queue
+                    var q3 = from eq in EmailQueueTos
+                             where eq.EmailQueue == emailqueue
+                             where eq.PeopleId == pid
+                             select eq;
+                    if (q3.Any())
+                    {
+                        continue;
+                    }
                     emailqueue.EmailQueueTos.Add(new EmailQueueTo
                     {
                         PeopleId = pid,

--- a/CmsWeb/Areas/Main/Views/Email/Compose.cshtml
+++ b/CmsWeb/Areas/Main/Views/Email/Compose.cshtml
@@ -98,7 +98,7 @@
                         }
                     }
                     <div>
-                        <ul class="pull-left" id="additional-recipients"></ul>
+                        <div class="pull-left"><ul id="additional-recipients"></ul></div>
                         <div class="pull-right">
                             <a class="searchadd btn btn-default btn-block" href="/SearchAdd2/Dialog/addtoemail/"><i class="fa fa-plus-circle"></i>  Add Recipient</a>
                         </div>

--- a/CmsWeb/Areas/Main/Views/Email/Compose.cshtml
+++ b/CmsWeb/Areas/Main/Views/Email/Compose.cshtml
@@ -246,13 +246,20 @@
     });
 
     function AddSelected(ret) {
-        $("#additional-recipients").append(
-            '<li id="additional-recipient-li-' + ret.pid + '">'+
-            ret.name +
-            '  <input type="hidden" name="AdditionalRecipients" value="' + ret.pid + '"/>' +
-            '  <a href="javascript:RemoveRecipient(' + ret.pid + ');"><i class="fa fa-times-circle red"></i></a>' +
-            '</li>'
-        );
+        // ret will be an array
+        for (var i = 0; i < ret.length; i++) {
+            // Check for duplicates among additional recipients
+            if ($("#additional-recipient-li-" + ret[i].pid).length) {
+                continue;
+            }
+            $("#additional-recipients").append(
+                '<li id="additional-recipient-li-' + ret[i].pid + '">' +
+                ret[i].name +
+                '  <input type="hidden" name="AdditionalRecipients" value="' + ret[i].pid + '"/>' +
+                '  <a href="javascript:RemoveRecipient(' + ret[i].pid + ');"><i class="fa fa-times-circle red"></i></a>' +
+                '</li>'
+            );
+        }
     }
 
     function RemoveRecipient(pid) {

--- a/CmsWeb/Areas/Search/Models/SearchAdd/SearchAddModel.cs
+++ b/CmsWeb/Areas/Search/Models/SearchAdd/SearchAddModel.cs
@@ -197,7 +197,7 @@ namespace CmsWeb.Areas.Search.Models
             PendingList.Add(pp);
         }
 
-        internal ReturnResult CommitAdd()
+        internal dynamic CommitAdd()
         {
             var id = PrimaryKeyForContextType;
             var iid = PrimaryKeyForContextType.ToInt();
@@ -253,7 +253,19 @@ namespace CmsWeb.Areas.Search.Models
                     break;
                 case "addtoemail":
                     if (PendingList.Count > 0)
-                        return new ReturnResult { close = true, how = "addselected", pid = PendingList[0].PeopleId, from = AddContext, name=PendingList[0].Person.Name };
+                    {
+                        var people = new List<ReturnResult>();
+                        foreach (var p in PendingList)
+                        {
+                            var email = p.Person.EmailAddress;
+                            if (email == null || email == "")
+                            {
+                                email = p.Person.EmailAddress2;
+                            }
+                            people.Add(new ReturnResult { close = true, how = "addselected", pid = p.PeopleId, from = AddContext, name = p.Person.Name, email = email });
+                        }
+                        return people;
+                    }
                     break;
             }
             return new ReturnResult {close = true, from = AddContext};
@@ -550,6 +562,7 @@ namespace CmsWeb.Areas.Search.Models
             public string message { get; set; }
             public string error { get; set; }
             public string key { get; set; }
+            public string email { get; set; }
         }
     }
 }


### PR DESCRIPTION
@hkouns I wasn't able to duplicate that layout issue in IE either (windows 10 comes with IE 11).  I've changed the pull-left to apply to a wrapping div rather than the ul.  If you're able to duplicate it in one of your browsers, let me know which browser and OS you're on and I'll try to duplicate and fix it on my end.  Thankfully MS provides virtual machine images for lots of combinations of OS + IE versions for testing this sort of thing:  https://dev.windows.com/en-us/microsoft-edge/tools/vms/linux/

Included in this PR:
- Attempt at fixing layout issue
- Handle duplicates in the GUI
- Prevent duplicates in EmailQueue server side
- Support selecting more than one person in searchadd
- Laid the groundwork for notifying user that selected person has no email address.  This is not finished though.
